### PR TITLE
Add instructions for installing/running hyrax via docker

### DIFF
--- a/Hyrax_BES_Configuration.adoc
+++ b/Hyrax_BES_Configuration.adoc
@@ -8,7 +8,7 @@
 == BES Configuration ==
 
 Once Hyrax is installed and running, you are free to keep the `Default` configurations 
-or costumize it to best fit your need and that of your data users. For the `BES`, there are two main ways that you can costumize the `BES` for your data by modifying
+or customize it to best fit your need and that of your data users. For the `BES`, there are two main ways that you can costumize the `BES` for your data by modifying
 
 <<bes_conf, Modifying the bes.conf file (Not Recommended)>>
 

--- a/Hyrax_BES_Configuration.adoc
+++ b/Hyrax_BES_Configuration.adoc
@@ -7,16 +7,13 @@
 [[bess-configuration]]
 == BES Configuration ==
 
-Building the BES and its data handlers from source (or installing from
-the Linux RPMs) will provide the default installation with data and a
-valid configuration. This is suitable for testing. There are two main ways 
-that you can costumize the BES for your data by modifying
+Once Hyrax is installed and running, you are free to keep the `Default` configurations 
+or costumize it to best fit your need and that of your data users. For the `BES`, there are two main ways that you can costumize the `BES` for your data by modifying
 
-1. _bes.conf_ file. Has default configurations, does not persist through updates.
-2. _site.conf_ file. Persists through updates.
+<<bes_conf, Modifying the bes.conf file (Not Recommended)>>
 
-Below we first describe the _bes.conf_ file in <<bes_conf>>, and subsequently 
-describe the recommended approach in <<site_conf>>. 
+<<site_conf, Changing the site.conf file (Recommended)>>
+
 
 NOTE: The syntax for modifying default values in _bes.conf_ is the same as that
 for modifing _site.conf_ file.
@@ -24,10 +21,10 @@ for modifing _site.conf_ file.
 [[bes_conf]]
 === Location of the BES Configuation File ===
 
-The BES configuration file is called _bes.conf_ and can be found in
-_$prefix/etc/bes/_ if you built the software from source or in
-_/etc/bes/_ if you used our RPM packages. By default _$prefix_ is in
-_/usr/local_.
+The `BES` default configuration file is called `bes.conf` and can be found in
+`$prefix/etc/bes/` if you built the software from source or in
+`/etc/bes/` if you used our RPM packages. By default `$prefix` is in
+`/usr/local`.
 
 === Basic format of parameters ===
 

--- a/Hyrax_BES_Installation.adoc
+++ b/Hyrax_BES_Installation.adoc
@@ -21,17 +21,14 @@ document Master_Hyrax_OLFS_Installation.
 
 It is necessary that you download and install both the _libdap_ and _BES_ binaries.
 
-. Visit the 
-  https://www.opendap.org/software/hyrax-data-server#block-hyraxversions-menu[Hyrax
-  Data Server Page].
-. Select the most recent in the list of *Available Versions*.
+. Visit the official OPeNDAP website and go to *Latest Release*.
 . Scroll down the following page until you reach the section entitled 
-  *Binaries for Hyrax x.x.x*, then continue scrolling until you
+  *Linux Binaries*, then continue scrolling until you
   see the heading titled *BES*.
-. You need to download both the _libdap_ and _BES_ RPMs which should be named
-  _libdap-x.x.x_ and _bes-x.x.x_.
+. You need to download both the `libdap` and `BES` RPMs which should be named
+  `libdap-x.x.x` and `bes-x.x.x`.
 . The downloaded files should be named something like
-  _libdap-x.x.x.el6.x86_64.rpm_ and _bes-x.x.x.static.el6.x86_64.rpm_.
+  `libdap-x.x.x.el6.x86_64.rpm` and `bes-x.x.x.static.el6.x86_64.rpm`.
 
 WARNING: In order to install the RPMs on your system, you *must* be running
 a 64bit OS. If you are running 32bit OS, attempting to install the 
@@ -43,9 +40,10 @@ from the Hyrax install page.
 ////
 == Install
 
-. Use yum to install the libdap and bes RPMs: +
-  `sudo yum install libdap-3.x.x.rpm bes-3.x.x.rpm`).
-. At this point you can test the BES by typing the following into a terminal:
+. **Install the libdap and bes RPMs**: +
+  `sudo yum install libdap-3.x.x.rpm bes-3.x.x.rpm`
+
+. **Test the `BES`**:
 .. start it: +
    `sudo service besd start` +
    (Or use the script in _/etc/init.d with sudo_: _/etc/init.d/besd start_)

--- a/Hyrax_DockerHub_Installation.adoc
+++ b/Hyrax_DockerHub_Installation.adoc
@@ -1,19 +1,19 @@
-= Installing via Docker Hub =
+= Docker Installation (Recommended) =
 :Miguel Jimenez-Urias <mjimenez@opendap.org>:
 {docdate}
 :numbered:
 :toc:
 
+This is the simplest way to install and use the latest release of Hyrax. 
 
+== Prerequisites
 
-This is the simplest way to install and get the latest Hyrax data server Running. Before doing so, we make the following assumptions about your system:
-
-. Have `Docker` running in the background.
-. You have a data folder under the directory `~/opendap/data/` .
-. Your data is stored in HDF5/NetCDF4 format.
+. `Docker` is running in the background.
+. You have a data folder. In this guide, we will assume it is `~/tmp/data/` .
+. Your data is stored in HDF5/NetCDF4 format, csv, or any other file format for which Hyrax has a data Handler (https://www.opendap.org/software/hyrax-data-server/[see all supported file formats by Hyrax])
 . OSX or Linux platform.
 
-== 3 Easy Steps to run Hyrax and serve data 
+== Run Hyrax and serve data
 
 . **Open a terminal and get the latest snapshot of hyrax**
 
@@ -21,18 +21,20 @@ This is the simplest way to install and get the latest Hyrax data server Running
 docker pull opendap/hyrax:snapshot
 ```
 
-This will download the latest stable, complete build of Hyrax (1.17.0). 
+TIP: Do not use `hyrax:latest`. We use Travis for CI/CD and `hyrax:snapshot` is fully tested, and packs with the correct versions needed to build Hyrax. Using `latest`, ironically may pull an older version of Hyrax.
+
+This will download the latest stable, complete build of Hyrax. 
 [start=2]
 . **Run Hyrax and make your data available on port `8080`**
 
 ```
 docker run -d -h hyrax -p 8080:8080 \
 --platform linux/amd64 \
---volume ~/opendap/data:/usr/share/hyrax \
+--volume ~/tmp/data:/usr/share/hyrax \
 --name=hyrax opendap/hyrax:snapshot
 ```
 
-The command above identifies the location of the data volume and assigns it to `/usr/share/hyrax`.
+The command above identifies the location of your data volume (`~/tmp/data`) and assigns it to `/usr/share/hyrax`, which is where Hyrax looks for data in the docker container.
 [start=3]
 . **Check data is available on local host**
 
@@ -40,7 +42,7 @@ By now, you can paste onto any browser the following url to see Hyrax's landing 
 ```
 http://localhost:8080/opendap/hyrax
 ```
-Make sure all your data is available.
+Make sure all your data is available and try to download some of it.
 
-If you want to learn how change the different configurations, check the overview on the xref:Hyrax_Configuration[Configuration]
+The installation of Hyrax comes with various default configutations. If you want to learn how to change the various default configurations, check the overview on the xref:Hyrax_Configuration[Configuration]
 

--- a/Hyrax_DockerHub_Installation.adoc
+++ b/Hyrax_DockerHub_Installation.adoc
@@ -1,0 +1,46 @@
+= Installing via Docker Hub =
+:Miguel Jimenez-Urias <mjimenez@opendap.org>:
+{docdate}
+:numbered:
+:toc:
+
+
+
+This is the simplest way to install and get the latest Hyrax data server Running. Before doing so, we make the following assumptions about your system:
+
+. Have `Docker` running in the background.
+. You have a data folder under the directory `~/opendap/data/` .
+. Your data is stored in HDF5/NetCDF4 format.
+. OSX or Linux platform.
+
+== 3 Easy Steps to run Hyrax and serve data 
+
+. **Open a terminal and get the latest snapshot of hyrax**
+
+```
+docker pull opendap/hyrax:snapshot
+```
+
+This will download the latest stable, complete build of Hyrax (1.17.0). 
+[start=2]
+. **Run Hyrax and make your data available on port `8080`**
+
+```
+docker run -d -h hyrax -p 8080:8080 \
+--platform linux/amd64 \
+--volume ~/opendap/data:/usr/share/hyrax \
+--name=hyrax opendap/hyrax:snapshot
+```
+
+The command above identifies the location of the data volume and assigns it to `/usr/share/hyrax`.
+[start=3]
+. **Check data is available on local host**
+
+By now, you can paste onto any browser the following url to see Hyrax's landing page
+```
+http://localhost:8080/opendap/hyrax
+```
+Make sure all your data is available.
+
+If you want to learn how change the different configurations, check the overview on the xref:Hyrax_Configuration[Configuration]
+

--- a/Hyrax_DockerHub_Installation.adoc
+++ b/Hyrax_DockerHub_Installation.adoc
@@ -8,7 +8,7 @@ This is the simplest way to install and use the latest release of Hyrax.
 
 == Prerequisites
 
-. `Docker` is running in the background.
+. `Docker daemon` process is running in the background.
 . You have a data folder. In this guide, we will assume it is `~/tmp/data/` .
 . Your data is stored in HDF5/NetCDF4 format, csv, or any other file format for which Hyrax has a data Handler (https://www.opendap.org/software/hyrax-data-server/[see all supported file formats by Hyrax])
 . OSX or Linux platform.
@@ -21,7 +21,7 @@ This is the simplest way to install and use the latest release of Hyrax.
 docker pull opendap/hyrax:snapshot
 ```
 
-TIP: Do not use `hyrax:latest`. We use Travis for CI/CD and `hyrax:snapshot` is fully tested, and packs with the correct versions needed to build Hyrax. Using `latest`, ironically may pull an older version of Hyrax.
+TIP: Do not use `hyrax:latest`. We use Travis for CI/CD and `hyrax:snapshot` is fully tested, and packs with the correct versions needed to build Hyrax. The `latest` tag is associated with the "latest" official release of the Hyrax server. Official releases are labor intensive to produce and only happen once or twice a year. To get the most recent and up-to-date software, get the `snapshot` tag.
 
 This will download the latest stable, complete build of Hyrax. 
 [start=2]
@@ -29,10 +29,11 @@ This will download the latest stable, complete build of Hyrax.
 
 ```
 docker run -d -h hyrax -p 8080:8080 \
---platform linux/amd64 \
 --volume ~/tmp/data:/usr/share/hyrax \
 --name=hyrax opendap/hyrax:snapshot
 ```
+
+NOTE: If you are on an OSX system running on Apple silicon (M-series CPUs) docker deployment, you will need the following extra line: `--platform linux/amd64 \`.
 
 The command above identifies the location of your data volume (`~/tmp/data`) and assigns it to `/usr/share/hyrax`, which is where Hyrax looks for data in the docker container.
 [start=3]

--- a/Hyrax_OLFS_Installation.adoc
+++ b/Hyrax_OLFS_Installation.adoc
@@ -152,3 +152,9 @@ server's output, make sure to run the command `bin/shutdown.sh`
 to shutdown Tomcat. If you don't, you may get errors when you next try
 to start the Tomcat server.
 ////
+
+
+
+NOTE: If you are installing the `OLFS` in conjunction with `ncWMS2` version 2.0 or higher, copy both the `opendap.war` and the `ncWMS2.war` files into the Tomcat `webapps` directory. (Re)Start Tomcat.
+
+

--- a/Hyrax_OLFS_Installation.adoc
+++ b/Hyrax_OLFS_Installation.adoc
@@ -6,14 +6,15 @@
 
 == Introduction
 
-The OLFS comes with a default configuration that is compatible with the
-default configuration of the BES. If you perform a default installation
+The `OLFS` comes with a default configuration that is compatible with the
+default configuration of the `BES`. If you perform a default installation
 of both, you should get a running Hyrax server that will be pre-populated
 with test data suitable for running integrity tests.
 
 == Install Tomcat
 
-. Use yum to install tomcat.noarch: `sudo yum install tomcat.noarch`.
+. **Install tomcat.noarch**: 
+  `sudo yum install tomcat.noarch`.
 . Create the directory `/etc/olfs`, change its group to tomcat, 
 and set it _group writable:_
 +
@@ -30,25 +31,24 @@ install it wherever you'd like--for example, `/usr/local/`.
 
 Follow the steps below to download the latest OLFS distribution:
 
-. Visit the 
-  https://www.opendap.org/software/hyrax-data-server#block-hyraxversions-menu[Hyrax
-  Data Server Page].
-. Select the most recent in the list of _Available Versions_.
-. Scroll down the following page until you reach the section titled 
-  _Binaries for Hyrax x.x.x_.
-. Directly underneath, you should see the OLFS download link, 
-  named something like _OLFS_x.x.x._Web_Archive_File_. Click to download.
-. The downloaded file will be named something like: _olfs-x.x.x-webapp.tgz_.
+. Visit the official OPeNDAP website and go to *Latest Release*.
+. Scroll down the following page until you reach the section entitled 
+  *Linux Binaries*
+. Directly underneath, you should see the `OLFS` download link, 
+  named something like `OLFS_x.x.x._Web_Archive_File`. Click to download.
+. The downloaded file will be named something like: `olfs-x.x.x-webapp.tgz`.
 
 == Unpack
 
-Unpack the jar file with the command `tar -xvf olfs-x.x.x-webapp.tgz`,
-which will unpack the files directory called _olfs-x.x.x-webapp_.
+Unpack the jar file with the command
+`tar -xvf olfs-x.x.x-webapp.tgz`
+
+This will unpack the files directory called `olfs-x.x.x-webapp`.
 
 == Install
 
-Inside of the _olfs-x.x.x-webapp_ directory, locate opendap.war and copy it into
-Tomcat's _webapps_ directory:
+Inside of the `olfs-x.x.x-webapp` directory, locate `opendap.war` and copy it into
+Tomcat's `webapps` directory:
 
 ....
 cp opendap.war /usr/share/tomcat/webapps

--- a/Hyrax_Source_Installation.adoc
+++ b/Hyrax_Source_Installation.adoc
@@ -100,7 +100,7 @@ This helps so that the server builds an installation locally, something that str
 source spath.sh 
 ```
 
-WARNING: Many of the problems people have with the build stem from not setting the shell correctly for the build. In the above section, make sure you run source spath.sh before you run any of the building/compiling/testing commands that use the source code or build files.
+WARNING: Many of the problems people have with the build stem from not setting the shell correctly for the build. In the above section, make sure you run `source spath.sh` before you run any of the building/compiling/testing commands that use the source code or build files.
 
 [start=4]
 . **Clone the three code repos for the server plus the hyrax dependencies**

--- a/Hyrax_Source_Installation.adoc
+++ b/Hyrax_Source_Installation.adoc
@@ -1,0 +1,160 @@
+= Hyrax GitHub Source Build
+:Miguel Jimenez-Urias <mjimenez@opendap.org>:
+{docdate}
+:numbered:
+:toc:
+
+This describes how to get and build Hyrax from our GitHub repositories.
+
+To build and install the server, you need to perform two steps:
+
+. <<setup, Set up the computer to build source code>> (Install a `Java` compiler; install a `C/C++` compiler; add some other tools)
+. <<semiauto, Build Hyrax using shell scripts>>
+
+
+[[setup]]
+== Setup Rocky 8 (RHEL8) to build source code
+
+The latest version of Hyrax (1.17.0) is build and tested using RHEL8. Below we describe the tools needed to build source code.
+
+. **Get the commands `ps`, `which`, etc.**
+
+```
+dnf install -y procps
+```
+
+[start=2]
+. **Get the `C++` environment plus build tools.**
+
+```
+dnf install -y git gcc-c++ flex bison cmake autoconf automake libtool emacs bzip2 vim bc
+```
+
+[start=3]
+. **Development library versions**
+
+```
+dnf install -y openssl-devel libuuid-devel readline-devel zlib-devel bzip2-devel libjpeg-devel libxml2-devel curl-devel libicu-devel libtirpc-devel
+```
+
+[start=4]
+. **Install Java**
+
+```
+dnf install -y java-17-openjdk java-17-openjdk-devel ant 
+```
+
+[start=5]
+. **Setup `DNF` so that we can load in some obscure packages from `EPEL`, etc., repos.**
+
+```
+dnf install dnf-plugins-core
+dnf install epel-release
+dnf config-manager --set-enabled powertools
+```
+
+[start=6]
+. **Install `CppUnit` and some more development libraries.**
+
+
+```
+dnf install -y cppunit cppunit-devel openjpeg2-devel jasper-devel
+```
+
+[start=7]
+. **Install the RPM tools**
+
+```
+dnf install -y rpm-devel rpm-build redhat-rpm-config
+```
+
+[start=8]
+. **Install the AWS CLI **
+
+```
+dnf install -y awscli
+```
+
+
+[[semiauto]]
+== Build Hyrax using semi-automatic build tools from repo
+
+Once the tools are installed on your local Linux (RHEL8) machine, we proceed to
+
+[start=1]
+. **Clone the Hyrax project repo**.
+```
+git clone https://github.com/OPENDAP/hyrax.git
+```
+and then `cd hyrax`.
+
+[start=2]
+. **Use `bash`.**
+The shell scripts in this repo assume you are using bash.
+
+[start=3]
+. **Set up some environment variables**. 
+This helps so that the server builds an installation locally, something that streamlines development.
+
+```
+source spath.sh 
+```
+
+WARNING: Many of the problems people have with the build stem from not setting the shell correctly for the build. In the above section, make sure you run source spath.sh before you run any of the building/compiling/testing commands that use the source code or build files.
+
+[start=4]
+. **Clone the three code repos for the server plus the hyrax dependencies**
+Because Hyrax data server is composed of https://github.com/OPENDAP/bes[BES], https://github.com/OPENDAP/olfs[OLFS] and https://github.com/OPENDAP/libdap4[libdap], each with their own separate repository, each needs to be compiled. The simple following shell scrips clones and downloads the repos:
+```
+./hyrax_clone.sh -v
+```
+
+[start=5]
+. **Build the code**, including the dependencies.
+
+```
+./hyrax_build.sh -v
+```
+
+[start=6]
+. **Test the Server**
+
+We strongly recommend to test the server. For that, do:
+
+[loweralpha, start=1]
+.. Start the `BES` with
+
+```
+besctl start
+```
+
+[loweralpha, start=2]
+.. Start the `OLFS` by:
+
+```
+./build/apache-tomcat-7.0.57/bin/startup.sh
+```
+
+[loweralpha, start=3]
+.. Look at Hyrax's landing page on localhost, i.e. paste the following URL on a browser:
+
+```
+http://localhost:8080/opendap
+```
+
+You should see a directory named `data` and following that link should lead to more data. The server will be accessible to clients other than a web browser.
+
+[loweralpha, start=4]
+.. To test the `BES` function independently of the front end, use
+
+```
+bescmdln
+```
+This snhould start the `BESClient>`. Then do:
+```
+BESClient> show version
+```
+and exit as follows:
+```
+BESClient> exit
+```

--- a/Hyrax_Source_Installation.adoc
+++ b/Hyrax_Source_Installation.adoc
@@ -15,7 +15,7 @@ To build and install the server, you need to perform two steps:
 [[setup]]
 == Setup Rocky 8 (RHEL8) to build source code
 
-The latest version of Hyrax (1.17.0) is build and tested using RHEL8. Below we describe the tools needed to build source code.
+The latest version of Hyrax (1.17.0) is build and tested using RHEL8. Below we describe the tools needed to build source code, and how to install them on Linux.
 
 . **Get the commands `ps`, `which`, etc.**
 

--- a/Master_Hyrax_Guide.adoc
+++ b/Master_Hyrax_Guide.adoc
@@ -35,7 +35,7 @@ include::Master_Hyrax_Overview.adoc[lines="1,8..-1"]
 
 // This document explains how to install Hyrax.
 [[Download_and_Install_Hyrax]]
-include::Master_Hyrax_Installation.adoc[lines="1,8..-1"]
+include::Master_Hyrax_Installation.adoc[lines="1,7..-1"]
 
 // General configuration informat
 include::Master_Hyrax_Configuration.adoc[lines="1,6..-1"]

--- a/Master_Hyrax_Installation.adoc
+++ b/Master_Hyrax_Installation.adoc
@@ -46,6 +46,12 @@ include::Hyrax_BES_Installation.adoc[lines="1,6..-1", leveloffset=+2]
 
 include::Hyrax_OLFS_Installation.adoc[lines="1,6..-1", leveloffset=+2]
 
+
+WARNING: If you are upgrading Hyrax from any previous installation older than 1.16.5, **read this!** The internal format of the `olfs.xml` file has been revised. No previous version of this file will work with Hyrax >=1.16.5. In order to upgrade your system, move your old configuration directory aside (`mv /etc/olfs ~/olfs-OLD`) and then follow the instruction to install a new `OLFS`. Once you have it installed and running you will need to review your old configuration and make the appropriate changes to the new `olfs.xml` to restore your server's behavior. The other `OLFS` configuration files have not undergone any structural changes and you may simply replace the new ones that were installed with copies of your previously working ones.
+
+NOTE: To make the server restart with when host boots, use `systemctl enable besd` and `systemctl enable tomcat`, or `chkconfig besd on` and `chkconfig tomcat on` depending on the specifics of your Linux distribution.
+
+
 [[source]]
 include::Hyrax_Source_Installation.adoc[lines="1,6..-1", leveloffset=+1]
 

--- a/Master_Hyrax_Installation.adoc
+++ b/Master_Hyrax_Installation.adoc
@@ -4,6 +4,8 @@
 :numbered:
 :toc:
 
+Hyrax is a data server that implements the DAP2 and DAP4 protocols, works with a number of different data formats and supports a wide variety of customization options from tailoring the look of the server's web pages to complex server-side processing operations. This page describes how to build the server's source code. If you're working on a Linux or OS/X computer, the process is similar so we describe only the linux case; we do not support building the server on Windows operating systems.
+
 There are broadly three ways to install and run Hyrax Data Server
 
 - <<dockerhub, Docker Hub>>
@@ -18,16 +20,21 @@ include::Hyrax_DockerHub_Installation.adoc[lines="1,6..-1", leveloffset=+1]
 [[binaries]]
 == (pre-compiled) Binaries
 
+Prerequisites:
+
+. `Java>=11`
+. `Tomcat>=9`
+
 Installing a Hyrax binary release typically involves the following steps
 
-. https://www.opendap.org/software/hyrax-data-server[Download the
-  latest Hyrax release] usually composed of:
-.. 2 RPM files (one for _libdap_, one for the _BES_).
-.. The OLFS binary distribution file.
-. Install the _libdap_ RPM.
-. Install the _BES_ RPM.
-. Unpack the OLFS distribution file, and install the _opendap.war_
-  file into your Tomcat instance's _webapps_ directory.
+. **Download the latest Hyrax release** (https://www.opendap.org/hyrax-1-17/[Hyrax 1.17]). It is composed of:
+.. 2 RPM files (one for `libdap`, one for the `BES`).
+.. The OLFS binary distribution file. You can also install the `OLFS Automatic robots.txt`, if available.
+. **Install the `libdap` RPM.**
+. **Install the `BES` RPM**.
+. **Unpack the `OLFS` distribution file**, and install the `opendap.war`
+  file into your Tomcat instance's `webapps` directory.
+. (optional) `ncWMS2`.  You will need to use the https://reading-escience-centre.github.io/edal-java/[EDAL] web page to locate the latest `ncWMS2` “Servlet Container” software bundle as a WAR file. Install it into the same Tomcat instance as the OLFS. See https://opendap.github.io/hyrax_guide/Master_Hyrax_Guide.html#WMS_Service[here for more instructions].
 
 TIP: The detailed download and installation instructions for Hyrax are
 published on the download page for each release of the server. Find
@@ -40,7 +47,9 @@ include::Hyrax_BES_Installation.adoc[lines="1,6..-1", leveloffset=+2]
 include::Hyrax_OLFS_Installation.adoc[lines="1,6..-1", leveloffset=+2]
 
 [[source]]
-== Github Source Code
+include::Hyrax_Source_Installation.adoc[lines="1,6..-1", leveloffset=+1]
+
+
 
 If you are interested in working on Hyrax or want to build the
 server from source code (as opposed to using the prebuilt binaries that we

--- a/Master_Hyrax_Installation.adoc
+++ b/Master_Hyrax_Installation.adoc
@@ -4,15 +4,29 @@
 :numbered:
 :toc:
 
-Installing a Hyrax binary release typically involves the following:
+There are broadly three ways to install and run Hyrax Data Server
 
-* https://www.opendap.org/software/hyrax-data-server[Download the
+- <<dockerhub, Docker Hub>>
+- <<binaries, (pre-compiled) Binaries>>
+- <<source, Github source files>>
+
+
+[[dockerhub]]
+include::Hyrax_DockerHub_Installation.adoc[lines="1,6..-1", leveloffset=+1]
+
+
+[[binaries]]
+== (pre-compiled) Binaries
+
+Installing a Hyrax binary release typically involves the following steps
+
+. https://www.opendap.org/software/hyrax-data-server[Download the
   latest Hyrax release] usually composed of:
-** 2 RPM files (one for _libdap_, one for the _BES_).
-** The OLFS binary distribution file.
-* Install the _libdap_ RPM.
-* Install the _BES_ RPM.
-* Unpack the OLFS distribution file, and install the _opendap.war_
+.. 2 RPM files (one for _libdap_, one for the _BES_).
+.. The OLFS binary distribution file.
+. Install the _libdap_ RPM.
+. Install the _BES_ RPM.
+. Unpack the OLFS distribution file, and install the _opendap.war_
   file into your Tomcat instance's _webapps_ directory.
 
 TIP: The detailed download and installation instructions for Hyrax are
@@ -21,9 +35,19 @@ the latest release and its associated installation details on
 https://www.opendap.org/software/hyrax-data-server[the Hyrax downloads
 page].
 
-include::Hyrax_BES_Installation.adoc[lines="1,6..-1", leveloffset=+1]
+include::Hyrax_BES_Installation.adoc[lines="1,6..-1", leveloffset=+2]
 
-include::Hyrax_OLFS_Installation.adoc[lines="1,6..-1", leveloffset=+1]
+include::Hyrax_OLFS_Installation.adoc[lines="1,6..-1", leveloffset=+2]
+
+[[source]]
+== Github Source Code
+
+If you are interested in working on Hyrax or want to build the
+server from source code (as opposed to using the prebuilt binaries that we
+provide), you can get signed source distributions from the
+https://www.opendap.org/software/hyrax-data-server[download page]
+referenced above. See also the <<for-developers, For Software Developers>>
+section below.
 
 == WCS Installation
 
@@ -32,11 +56,4 @@ For more information about configuring WCS with your installation of Hyrax,
 please refer to the <<WCS_installation_guide, WCS Installation Guide>> that
 appears later in this document.
 
-== Source Code Builds
 
-If you are interested in working on Hyrax or want to build the
-server from source code (as opposed to using the prebuilt binaries that we
-provide), you can get signed source distributions from the
-https://www.opendap.org/software/hyrax-data-server[download page]
-referenced above. See also the <<for-developers, For Software Developers>>
-section below.


### PR DESCRIPTION
Closes #15 

- [x] Adds instructions on how to install/run hyrax via docker
- [x] Check that other forms of installation are complete (see https://github.com/OPENDAP/hyrax_guide/issues/6#issuecomment-2364136985 )

I added a new section on building hyrax from Source/Github, which mas also missing, following the text on the old website https://docs.opendap.org/index.php/Hyrax_GitHub_Source_Build. In particular, I copied a lot of the content from:

- [Rocky8](https://docs.opendap.org/index.php/Hyrax_GitHub_Source_Build#Rocky_8) 
- [Semiautomatic](https://docs.opendap.org/index.php/Hyrax_GitHub_Source_Build#A_semi-automatic_build)

into the new subsection **3.3 Hyrax GitHub Source Build**


