### PR TITLE
Bundle configuration and customization together 

### DIFF
--- a/Hyrax_BES_Configuration.adoc
+++ b/Hyrax_BES_Configuration.adoc
@@ -4,7 +4,6 @@
 //:numbered:
 //:toc:
 
-When you install Hyrax for the first time it is pre-configured to serve test data sets that come with each of the installed data handlers. This will allow you to test the server and make sure it is functioning correctly. After that you can customize it for your data.
 
 [[bess-configuration]]
 = BES Configuration =

--- a/Master_Hyrax_Customizing_Hyrax.adoc
+++ b/Master_Hyrax_Customizing_Hyrax.adoc
@@ -1,16 +1,13 @@
-= Customizing Hyrax
+= Configuring and Customizing Hyrax
 :Leonard Porrello <lporrel@gmail.com>:
 {docdate}
 :numbered:
 :toc:
 
-== Introduction
 
-There are several ways in which Hyrax can be customized:
+// General configuration informat
+include::Master_Hyrax_Configuration.adoc[lines="1,6..-1"]
 
-* Web interface look and feel can be changed, as can the pages served.
-* Custom DispatchHandlers for the OLFS
-* Custom RequestHandlers for the BES.
 
 == Webpage Customization
 

--- a/Master_Hyrax_Customizing_Hyrax.adoc
+++ b/Master_Hyrax_Customizing_Hyrax.adoc
@@ -226,16 +226,3 @@ elements have XML _type_ attributes that are not currently recognized by
 any OPeNDAP software. _Not currently in use._
 |=======================================================================
 
-== Software Customization
-
-=== OLFS Customization
-
-http://www.opendap.org/support/bom_sdw/SDW_2r0_OLFSExtensions.ppt[Power
-Point Presentation From the 2007 Software Development Workshop hosted by
-the Australian Bureau of Meteorology.]
-
-=== BES Customization
-
-http://www.opendap.org/support/bom_sdw/SDW_4r0_BESExtensibility.ppt[Power
-Point Presentation From the 2007 Software Development Workshop hosted by
-the Australian Bureau of Meteorology.]

--- a/Master_Hyrax_Guide.adoc
+++ b/Master_Hyrax_Guide.adoc
@@ -37,11 +37,8 @@ include::Master_Hyrax_Overview.adoc[lines="1,8..-1"]
 [[Download_and_Install_Hyrax]]
 include::Master_Hyrax_Installation.adoc[lines="1,7..-1"]
 
-// General configuration informat
-include::Master_Hyrax_Configuration.adoc[lines="1,6..-1"]
-
 // Customize the way the server looks when used with a web browser.
-include::Master_Hyrax_Customizing_Hyrax.adoc[lines="1,8..-1"]
+include::Master_Hyrax_Customizing_Hyrax.adoc[lines="1,6..-1"]
 
 // Integrate Hyrax with the Apache web demon.
 [[apache-integration]]


### PR DESCRIPTION
This PR:

- [x] Moves Configuration out of installation
- [x] Bundles Config with Customization. 

This PR does NOT address the broken URL related to the [2007 presentations about Software Customization](https://opendap.github.io/hyrax_guide/Master_Hyrax_Guide.html#_software_customization) (see #20 ). I would like to remove them from the text, but I am not sure what to replace them with...


See screenshot below:

![Screenshot 2024-11-21 at 8 01 01 AM](https://github.com/user-attachments/assets/c80770bf-7e98-4ebb-ba54-31ea709191fe)



